### PR TITLE
Recurse on last node in case it is a dir

### DIFF
--- a/model_viewer/model_viewer.pas
+++ b/model_viewer/model_viewer.pas
@@ -504,6 +504,7 @@ procedure LoadMeshFilelist;
     if fnode^.is_directory then begin
         for i := 0 to Length(fnode^.nodes)-2 do  //hob/hmt always go in pairs
             AddFile(path + fnode^.Name + '/', fnode^.nodes[i], fnode^.nodes[i+1]);
+        AddFile(path + fnode^.Name + '/', fnode^.nodes[Length(fnode^.nodes)-1], nil); // in case last is a directory (e.g. dbg)
     end
     else begin
         name := fnode^.name;


### PR DESCRIPTION
Concrete example: dbg dir containing dbg_{HOB,HMT} was not parsed.