### PR TITLE
First attempt to display further face data

### DIFF
--- a/model_viewer/hob_mesh.pas
+++ b/model_viewer/hob_mesh.pas
@@ -135,7 +135,7 @@ begin
   fg_idx := 0;
   robject.parts := TObjectPartList.Create;
 
-  for fg in hobject.object_parts do begin
+  for fg in hobject.face_groups do begin
       current_block_vertices.Clear;
       robjpart.triangles := TTriangleList.Create;
       robjpart.vertices := TVertexList.Create;


### PR DESCRIPTION
Looking at the HOB files (see #10) I noticed that each meshdef0 ("object part") could be associated with multiple meshdef1 structs ("face groups"/"object subparts" - I don't know what the best terminology is). This is a rough attempt to restructure `hob_parser` and `model_viewer` to account for this and recover more face/vertex data. It works for many models, but `data2/koelsch_HOB` doesn't look quite right and `data/level/lv_4/opkg_HOB` gives a `mesh loading failed :(` message (this is strange since my python parser doesn't have any issues, but I may not be looking closely enough e.g. at the HMT yet). 

Anyway I thought I'd put this here as a "work in progress". Maybe a better data structure would be for each THobObjectPart to contain an array/list of THobFaceGroup.